### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -110,6 +110,8 @@ jobs:
   build:
     needs: [test, security-scan]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Run on main branch pushes OR on releases
     if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event_name == 'release'
     


### PR DESCRIPTION
Potential fix for [https://github.com/ryannortham/scorecard/security/code-scanning/12](https://github.com/ryannortham/scorecard/security/code-scanning/12)

To fix the issue, add an explicit `permissions` block to the `build` job in the workflow file. This block should specify the least privileges required for the job to function correctly. Based on the operations performed in the `build` job, the `contents: read` permission is sufficient, as the job does not modify repository contents or require write access.

The `permissions` block should be added immediately after the `runs-on` key in the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
